### PR TITLE
Only display the dashboard link if the server is not running.

### DIFF
--- a/app/View/Layouts/sbv1_notrunning.ctp
+++ b/app/View/Layouts/sbv1_notrunning.ctp
@@ -127,6 +127,7 @@ END;
 			        		<li class="<?php if ($this->name == "DashController") { echo "current" ; }  ?> bounce fadein"> 
 							<a href="<?php echo $this->Html->url('/dash', true); ?>"> <span class="icon dashboard"></span><?php echo __(' Dashboard') ?></a> 
 			        		</li>
+			        		<?php } ?>
 					        </ul>
 					</nav>
 					<!-- End Navigation --> 

--- a/app/View/Layouts/sbv1_notrunning.ctp
+++ b/app/View/Layouts/sbv1_notrunning.ctp
@@ -123,13 +123,11 @@ END;
 					<!-- Navigation -->
 					<nav id="mainnav">
 						<ul>
-					        <li class="bounce fadein"> <a href="./dash"> <span class="icon dashboard"></span> <?php echo __('Dashboard'); ?> </a> </li>
-					        <li class="bounce fadein"> <a href="./tusers"> <span class="icon users"></span> <?php echo __('Users'); ?> </a> </li>
-					        <li class="bounce fadein"> <a href="./tplugins"> <span class="icon plugins"></span> <?php echo __('Plugins'); ?> </a> </li>
-					        <li class="bounce fadein"> <a href="./tworlds"> <span class="icon world"></span> <?php echo __('Worlds'); ?> </a> </li>
-					        <li class="bounce fadein"> <a href="./tservers"> <span class="icon server"></span> <?php echo __('Server'); ?> </a> </li>
-					        <li class="bounce fadein floatright"> <a href="./tsettings"> <span class="icon settings"></span> <?php echo __('Settings'); ?> </a> </li>
-						</ul>
+						<?php if (($user_perm['pages'] & $glob_perm['pages']['dash']) || ($user_perm['is_super'] == 1)) { ?>
+			        		<li class="<?php if ($this->name == "DashController") { echo "current" ; }  ?> bounce fadein"> 
+							<a href="<?php echo $this->Html->url('/dash', true); ?>"> <span class="icon dashboard"></span><?php echo __(' Dashboard') ?></a> 
+			        		</li>
+					        </ul>
 					</nav>
 					<!-- End Navigation --> 
 


### PR DESCRIPTION
[Bootscreen](https://github.com/Bootscreen) submitted an [issue](https://github.com/SpaceDev/SpaceBukkit/issues/134) over at the SpaceBukkit repo regarding the links in the main navigation when the current selected server is turned off. He noticed that the link that would take you to the players if the server was running actually was referencing a non-existent TUsersController (I guess some old artifact), so it simply is a wrong link. Moreover I propose that you only should see the link to the dashboard while the server is stopped, simply because the others are not needed at that time.

Best regards,
-Pit
